### PR TITLE
Allow async create functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-module.exports = function (deps) {
+module.exports = async function (deps) {
   var res = {}
 
   var foundOne = false
@@ -23,8 +23,12 @@ module.exports = function (deps) {
       if (!gotAll) continue
 
       // Create the dep
-      var obj = dep.create(api)
-      res[dep.gives] = obj
+      var obj = await dep.create(api, dep.opts)
+      if (typeof dep.gives === 'string') {
+        res[dep.gives] = obj
+      } else if (Array.isArray(dep.gives)) {
+        dep.gives.forEach(key => { res[key] = obj[key] })
+      }
       foundOne = true
     }
 


### PR DESCRIPTION
Very nice and simple module!
I started using depj, and then needed async create functions. This very simple patch made it work, like a charm.

As in this WIP PR, it would be a breaking change (making the main function return a promise). I think I could add an option as second arg to switch between sync and async mode. What do you think?

I first tried to keep it all sync, and might go back to this, but that means a lot of ready() functions or similar, which then would need additional effort to keep them running in the right order. With this patch it just works (sequentially, which is fine for my usage at the moment).

Before, I used [avvio](/mcollina/avvio) but that does not have dependency injection, is more complex, and I quite like the simplicity of depj.